### PR TITLE
Rewrite initialization & implement multi-client support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@notross/mongo-singleton",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
   "types": "./dist/cjs/index.d.ts",

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -1,0 +1,93 @@
+import {
+  InitClientProps,
+  UseClientResponse,
+} from './types';
+import { MongoSingleton } from './mongo-singleton';
+
+type SingletonClients = Record<string, MongoSingleton>;
+
+class State {
+  private _clients: SingletonClients = {};
+
+  public add: (clientId: string, client: MongoSingleton) => void;
+  public set: (client: SingletonClients) => void;
+  public get: (clientId: string) => MongoSingleton | undefined;
+  public clients: SingletonClients;
+
+  constructor() {
+    this.add = this.addClient.bind(this);
+    this.set = this.setClient.bind(this);
+    this.get = this.getClient.bind(this);
+    this.clients = this._clients;
+  }
+
+  private addClient(clientId: string, client: MongoSingleton): void {
+    if (this._clients[clientId]) {
+      console.warn(`A client with ID ${clientId} already exists.`)
+    } else {
+      this.setClient({ [clientId]: client });
+    }
+  }
+
+  private setClient(client: SingletonClients): void {
+    this._clients = { ...this._clients, ...client };
+    this.clients = this._clients;
+  }
+
+  public getClient(clientId: string): MongoSingleton | undefined {
+    return this._clients[clientId];
+  }
+  public getClients(): SingletonClients {
+    return this._clients;
+  }
+}
+const state = new State();
+
+class Stateful {
+  private clientId: string;
+  public client: MongoSingleton;
+  public set: (client: MongoSingleton) => void;
+  public get: () => MongoSingleton;
+
+  constructor(clientId: string, props?: InitClientProps) {
+    this.set = this.update.bind(this);
+    this.get = this.getClient.bind(this);
+    this.clientId = clientId;
+    this.client = state.get(clientId) || this.createClient(props);
+  }
+
+  private createClient(props?: InitClientProps): MongoSingleton {
+    const client = new MongoSingleton(props);
+    state.add(this.clientId, client);
+    this.update(client);
+    return client;
+  }
+
+  private getClient(): MongoSingleton {
+    return state.get(this.clientId) as MongoSingleton;
+  }
+
+  private update(
+    value: MongoSingleton | ((v: MongoSingleton) => MongoSingleton),
+  ) {
+    if (typeof value === 'function') {
+      value = value(this.getClient());
+    }
+
+    state.set({ [this.clientId]: value });
+    this.client = value;
+  }
+}
+
+export const useClient = (
+  clientId: string,
+  props?: InitClientProps,
+): UseClientResponse => {
+  const { client } = new Stateful(clientId, props);
+
+  return {
+    client,
+    collection: client.collection,
+    db: client.db,
+  };
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { MongoSingleton } from './mongo-singleton';
 
 const mongoClient = new MongoSingleton();
 const db = mongoClient.db;
+const getDb = mongoClient.connectedDb;
 const collection = mongoClient.collection;
 const configure = mongoClient.configure;
 
@@ -10,6 +11,7 @@ export {
   collection,
   configure,
   db,
+  getDb,
   mongoClient,
   MongoSingleton,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,3 +15,4 @@ export {
   mongoClient,
   MongoSingleton,
 };
+export * from './types';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { MongoSingleton } from './mongo-singleton';
 
 const mongoClient = new MongoSingleton();
-const getDb = mongoClient.db;
+const db = mongoClient.db;
 const collection = mongoClient.collection;
 const configure = mongoClient.configure;
 
@@ -9,7 +9,7 @@ export default MongoSingleton;
 export {
   collection,
   configure,
-  getDb,
+  db,
   mongoClient,
   MongoSingleton,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,11 @@ import { MongoSingleton } from './mongo-singleton';
 
 const mongoClient = new MongoSingleton();
 const getDb = mongoClient.db;
-const _collection = mongoClient._collection;
 const collection = mongoClient.collection;
 const configure = mongoClient.configure;
 
 export default MongoSingleton;
 export {
-  _collection,
   collection,
   configure,
   getDb,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { MongoSingleton } from './mongo-singleton';
+import { useClient } from './clients';
 
 const mongoClient = new MongoSingleton();
 const db = mongoClient.db;
@@ -14,5 +15,6 @@ export {
   getDb,
   mongoClient,
   MongoSingleton,
+  useClient,
 };
 export * from './types';

--- a/src/mongo-singleton.ts
+++ b/src/mongo-singleton.ts
@@ -1,10 +1,11 @@
 import * as mongodb from 'mongodb';
 import { logger, LogLevel } from '@notross/node-client-logger';
 import {
+  ConnectAndGetDb,
   ConnectionOptions,
   ConnectionProps,
   GetCollection,
-  GetDb,
+  GetDatabase,
   InitClient,
   InitClientProps,
   SetConfig,
@@ -31,7 +32,8 @@ export class MongoSingleton {
   public error?: any = null;
   public init: InitClient;
   public collection: GetCollection;
-  public db: GetDb;
+  public connectedDb: ConnectAndGetDb;
+  public db: GetDatabase;
   public configure: SetConfig;
 
   /**
@@ -48,7 +50,8 @@ export class MongoSingleton {
     this.setConfig(props?.config);
     this.collection = this.getCollection.bind(this);
     this.configure = this.setConfig.bind(this);
-    this.db = this.getDb.bind(this);
+    this.connectedDb = this.getDb.bind(this);
+    this.db = this._getDb.bind(this);
     this.init = this.setup.bind(this);
   }
 
@@ -104,7 +107,7 @@ export class MongoSingleton {
     return this.database;
   }
 
-  private _getDb(
+  public _getDb(
     client: mongodb.MongoClient,
   ): mongodb.Db {
     return this.database || this.initializeDatabase(client);

--- a/src/mongo-singleton.ts
+++ b/src/mongo-singleton.ts
@@ -71,6 +71,8 @@ export class MongoSingleton {
     if (config) {
       this.setConfig(config);
     }
+
+    this.initializeClient();
   }
 
   private setConfig(
@@ -96,21 +98,18 @@ export class MongoSingleton {
       return this.client;
     }
 
-    const client = new mongodb.MongoClient(this.uri, this.config);
-    return client;
+    this.client = new mongodb.MongoClient(this.uri, this.config);
+    return this.client;
   }
 
-  private initializeDatabase(
-    client: mongodb.MongoClient,
-  ): mongodb.Db {
+  private initializeDatabase(): mongodb.Db {
+    const client = this.client as mongodb.MongoClient;
     this.database = client.db(this.databaseName);
     return this.database;
   }
 
-  public _getDb(
-    client: mongodb.MongoClient,
-  ): mongodb.Db {
-    return this.database || this.initializeDatabase(client);
+  public _getDb(): mongodb.Db {
+    return this.database || this.initializeDatabase();
   }
 
   /**
@@ -128,60 +127,58 @@ export class MongoSingleton {
     if (this.client) {
       return {
         client: this.client,
-        database: this._getDb(this.client),
+        database: this._getDb(),
       };
     }
 
-    this.client = this.initializeClient();
-    await this.client.connect().then(
-      (client) => this.initializeDatabase(client)
-    );
+    const client = this.initializeClient();
+    await client.connect().then(() => this.initializeDatabase());
 
-    this.client.on('connectionReady', () => {
+    client.on('connectionReady', () => {
       this.status = 'MongoDB connection is ready';
       logger.log(this.status);
     });
-    this.client.on('close', () => {
+    client.on('close', () => {
       this.status = 'MongoDB connection closed';
       logger.log(this.status);
     });
-    this.client.on('error', (err) => {
+    client.on('error', (err) => {
       this.status = 'MongoDB connection error';
       this.error = err;
       logger.error(this.status, err);
     });
-    this.client.on('reconnect', () => {
+    client.on('reconnect', () => {
       this.status = 'MongoDB reconnected';
       logger.log(this.status);
     });
-    this.client.on('reconnectFailed', () => {
+    client.on('reconnectFailed', () => {
       this.status = 'MongoDB reconnection failed';
       logger.error(this.status);
     });
-    this.client.on('timeout', () => {
+    client.on('timeout', () => {
       this.status = 'MongoDB connection timed out';
       logger.error(this.status);
     });
-    this.client.on('serverHeartbeatFailed', (err) => {
+    client.on('serverHeartbeatFailed', (err) => {
       this.status = 'MongoDB server heartbeat failed:';
       this.error = err;
       logger.error(this.status, this.error);
     });
-    this.client.on('serverHeartbeatSucceeded', () => {
+    client.on('serverHeartbeatSucceeded', () => {
       this.status = 'MongoDB server heartbeat succeeded';
       logger.log(this.status);
     });
-    this.client.on('serverClosed', () => {
+    client.on('serverClosed', () => {
       this.status = 'MongoDB server closed';
       logger.log(this.status);
     });
-    this.client.on('serverOpening', () => {
+    client.on('serverOpening', () => {
       this.status = 'MongoDB server opening';
       logger.log(this.status);
     });
     return {
-      client: this.client,
-      database: this._getDb(this.client),
+      client: client,
+      database: this._getDb(),
     };
   }
 
@@ -215,6 +212,7 @@ export class MongoSingleton {
   public getCollection(
     name: string,
   ): mongodb.Collection<mongodb.Document> {
-    return this.database!.collection(name);
+    const database = this._getDb();
+    return database.collection(name);
   }
 }

--- a/src/mongo-singleton.ts
+++ b/src/mongo-singleton.ts
@@ -4,7 +4,6 @@ import {
   ConnectionOptions,
   ConnectionProps,
   GetCollection,
-  GetCollectionPromise,
   GetDb,
   InitClient,
   InitClientProps,
@@ -31,8 +30,7 @@ export class MongoSingleton {
   public status: string = 'Disconnected';
   public error?: any = null;
   public init: InitClient;
-  public _collection: GetCollection;
-  public collection: GetCollectionPromise;
+  public collection: GetCollection;
   public db: GetDb;
   public configure: SetConfig;
 
@@ -48,7 +46,6 @@ export class MongoSingleton {
       this.setup(props);
     }
     this.setConfig(props?.config);
-    this._collection = this._getCollection.bind(this);
     this.collection = this.getCollection.bind(this);
     this.configure = this.setConfig.bind(this);
     this.db = this.getDb.bind(this);
@@ -212,17 +209,9 @@ export class MongoSingleton {
     return database;
   }
 
-  public _getCollection(
+  public getCollection(
     name: string,
   ): mongodb.Collection<mongodb.Document> {
     return this.database!.collection(name);
-  }
-
-  public async getCollection(
-    name: string,
-  ): Promise<mongodb.Collection<mongodb.Document>> {
-    const database = await this.db();
-    const collection = database.collection(name);
-    return collection;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 import * as mongodb from 'mongodb';
 
+export { mongodb };
 /**
  * Full connection properties used to build the MongoDB URI.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,4 @@ export type SetConfig = (
 export type GetCollection = (
   name: string,
 ) => mongodb.Collection<mongodb.Document>;
-export type GetCollectionPromise = (
-  name: string,
-) => Promise<mongodb.Collection<mongodb.Document>>;
 export type GetDb = () => Promise<mongodb.Db>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,4 +41,5 @@ export type SetConfig = (
 export type GetCollection = (
   name: string,
 ) => mongodb.Collection<mongodb.Document>;
-export type GetDb = () => Promise<mongodb.Db>;
+export type ConnectAndGetDb = () => Promise<mongodb.Db>;
+export type GetDatabase = (client: mongodb.MongoClient) => mongodb.Db;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as mongodb from 'mongodb';
+import { MongoSingleton } from './mongo-singleton';
 
 export { mongodb };
 /**
@@ -32,6 +33,11 @@ export type InitClientProps = {
   config?: mongodb.MongoClientOptions;
 };
 
+export type UseClientResponse = {
+  client: MongoSingleton;
+  collection: GetCollection;
+  db: GetDatabase;
+};
 export type SingletonClient = mongodb.MongoClient | null;
 export type InitClient = (
   props: InitClientProps,


### PR DESCRIPTION
- Refactor MongoSingleton to operate passively
- Make `collection` helper available without promise
- Initialize `mongodb.client` upon MongoSingleton instantiation
- Initialize `mongodb.database` upon `mongodb.client` initialization
- Add multi-client support
- Rename methods and exports for simplicity
- Export `mongodb` package typedefs from package
- Update documentation to accommodate client revisions